### PR TITLE
Polyfill: Copy over attributes on the <math> node

### DIFF
--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,5 +1,12 @@
 export function polyfill(mathNode: Element): Element {
   const root = document.createElement(getCustomElementName(mathNode));
+  const attrs = mathNode.attributes;
+  if (attrs && attrs.length) {
+    for (let x = 0; x < attrs.length; x++) {
+      const attr = attrs[x];
+      root.setAttribute(attr.name, attr.value);
+    }
+  }
   polyfillChildren(root, mathNode);
   const parent = mathNode.parentElement;
   if (parent) {


### PR DESCRIPTION
Hi Preet,

Thank you for creating this library. It works great as a polyfill!

I use both inline as well as block math elements on my pages. For that, I use the attribute `display` (an official attribute from the MathML spec) like so and react on it in my CSS:

```html
<math display="block">
...
</math>
```

Unfortunately, the polyfill currently does not copy over attributes on the root element. I've fixed this in this PR. Let me know in case further changes are needed.