### PR TITLE
Fix torture test

### DIFF
--- a/examples/torture.html
+++ b/examples/torture.html
@@ -94,10 +94,10 @@
 
   <script>
     const data = [
-      { img: 'https://mdn.mozillademos.org/files/3076/ex1.png', math: `<math display="block"><mrow><msup><mi>x</mi><mn>2</mn></msup><msup><mi>y</mi><mn>2</mn></msup></mrow></math>` },
-      { img: 'https://developer.mozilla.org/@api/deki/files/4579/=ex2.png', math: `<math display="block"><mrow><mmultiscripts><mi>F</mi><mn>3</mn><none></none><mprescripts></mprescripts><mn>2</mn><none></none></mmultiscripts></mrow></math>` },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex1.png', math: `<math display="block"><mrow><msup><mi>x</mi><mn>2</mn></msup><msup><mi>y</mi><mn>2</mn></msup></mrow></math>` },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex2.png', math: `<math display="block"><mrow><mmultiscripts><mi>F</mi><mn>3</mn><none></none><mprescripts></mprescripts><mn>2</mn><none></none></mmultiscripts></mrow></math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4586/=ex21.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex21.png', math: `<math display="block">
         <mrow>
           <mfrac>
             <mrow>
@@ -117,7 +117,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4587/=ex22.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex22.png', math: `<math display="block">
         <mrow>
           <mi>x</mi>
           <mo>+</mo>
@@ -134,10 +134,10 @@
           </msup>
         </mrow>
       </math>` },
-      { img: 'https://developer.mozilla.org/@api/deki/files/4588/=ex23.png', math: "<math display=\"block\"><mrow><mfrac><mi>a</mi><mrow><mi>b</mi><mo>/</mo><mn>2</mn></mrow></mfrac></mrow></math>" },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex23.png', math: "<math display=\"block\"><mrow><mfrac><mi>a</mi><mrow><mi>b</mi><mo>/</mo><mn>2</mn></mrow></mfrac></mrow></math>" },
       {
         tofix: true,
-        img: 'https://developer.mozilla.org/@api/deki/files/4589/=ex24.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex24.png', math: `<math display="block">
         <mrow>
           <msub>
             <mi>a</mi>
@@ -186,7 +186,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4590/=ex25.png', math: `<math>
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex25.png', math: `<math>
         <mrow>
           <msub>
             <mi>a</mi>
@@ -234,9 +234,9 @@
           </mfrac>
         </mrow>
       </math>` },
-      { img: 'https://developer.mozilla.org/@api/deki/files/4591/=ex26.png', math: `<math display="block"><mrow><mo>(</mo><mfrac linethickness="0px"><mi>n</mi><mrow><mi>k</mi><mo>/</mo><mn>2</mn></mrow></mfrac><mo>)</mo></mrow></math>` },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex26.png', math: `<math display="block"><mrow><mo>(</mo><mfrac linethickness="0px"><mi>n</mi><mrow><mi>k</mi><mo>/</mo><mn>2</mn></mrow></mfrac><mo>)</mo></mrow></math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4592/=ex27.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex27.png', math: `<math display="block">
         <mrow>
           <mrow>
             <mo>(</mo>
@@ -281,7 +281,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4593/=ex29.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex29.png', math: `<math display="block">
         <mrow>
           <munder>
             <mo>∑</mo>
@@ -312,9 +312,9 @@
           <mo stretchy="false">)</mo>
         </mrow>
       </math>` },
-      { img: 'https://developer.mozilla.org/@api/deki/files/4580/=ex3.png', math: "<math display=\"block\"><mrow><msup><mi>x</mi><mrow><mn>2</mn><mi>y</mi></mrow></msup></mrow></math>" },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex3.png', math: "<math display=\"block\"><mrow><msup><mi>x</mi><mrow><mn>2</mn><mi>y</mi></mrow></msup></mrow></math>" },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4594/=ex30.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex30.png', math: `<math display="block">
         <mrow>
           <munderover>
             <mo>∑</mo>
@@ -367,7 +367,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4595/=ex31.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex31.png', math: `<math display="block">
         <mrow>
           <msqrt>
             <mn>1</mn>
@@ -401,7 +401,7 @@
         </mrow>
       </math>`},
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4596/=ex34.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex34.png', math: `<math display="block">
         <mrow>
           <mrow>
             <mo>(</mo>
@@ -452,9 +452,9 @@
           <mn>0</mn>
         </mrow>
       </math>` },
-      { img: 'https://developer.mozilla.org/@api/deki/files/4581/=ex4.png', math: "<math display=\"block\"><mrow><msup><mn>2</mn><msup><mn>2</mn><msup><mn>2</mn><mi>x</mi></msup></msup></msup></mrow></math>" },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex4.png', math: "<math display=\"block\"><mrow><msup><mn>2</mn><msup><mn>2</mn><msup><mn>2</mn><mi>x</mi></msup></msup></msup></mrow></math>" },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4597/=ex40.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex40.png', math: `<math display="block">
         <mrow>
           <msubsup>
             <mo stretchy="false">∫</mo>
@@ -468,7 +468,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4599/=ex41.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex41.png', math: `<math display="block">
         <mrow>
           <msub>
             <mo>∬ </mo>
@@ -480,7 +480,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4600/=ex43.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex43.png', math: `<math display="block">
         <mrow>
           <mi>f</mi>
           <mo stretchy="false">(</mo>
@@ -543,7 +543,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4601/=ex44.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex44.png', math: `<math display="block">
         <mover>
           <mrow>
             <mi>x</mi>
@@ -558,9 +558,9 @@
           </mover>
         </mover>
       </math>` },
-      { img: 'https://developer.mozilla.org/@api/deki/files/4582/=ex5.png', math: "<math display=\"block\"><mrow><msub><mi>y</mi><msup><mi>x</mi><mn>2</mn></msup></msub></mrow></math>" },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex5.png', math: "<math display=\"block\"><mrow><msub><mi>y</mi><msup><mi>x</mi><mn>2</mn></msup></msub></mrow></math>" },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4602/=ex51.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex51.png', math: `<math display="block">
         <mrow>
           <munder>
             <mo>∑</mo>
@@ -595,7 +595,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4603/=ex52.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex52.png', math: `<math display="block">
         <mrow>
           <mo stretchy="false">{</mo>
           <munder>
@@ -654,7 +654,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4604/=ex53.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex53.png', math: `<math display="block">
         <mrow>
           <mo>(</mo>
           <mtable>
@@ -743,7 +743,7 @@
       </math>` },
       {
         tofix: true,
-        img: 'https://developer.mozilla.org/@api/deki/files/4605/=ex54.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex54.png', math: `<math display="block">
         <mrow>
           <mi>det</mi>
           <mo>|</mo>
@@ -905,9 +905,9 @@
           <mn>0</mn>
         </mrow>
       </math>` },
-      { img: 'https://developer.mozilla.org/@api/deki/files/4598/=ex6.png', math: "<math display=\"block\"><msub><mi>y</mi><msub><mi>x</mi><mn>2</mn></msub></msub></math>" },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex6.png', math: "<math display=\"block\"><msub><mi>y</mi><msub><mi>x</mi><mn>2</mn></msub></msub></math>" },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4583/=ex7.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex7.png', math: `<math display="block">
         <mrow>
           <msubsup>
             <mi>x</mi>
@@ -919,7 +919,7 @@
         </mrow>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4584/=ex8.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex8.png', math: `<math display="block">
         <msubsup>
           <mi>x</mi>
           <msubsup>
@@ -935,15 +935,15 @@
         </msubsup>
       </math>` },
       {
-        img: 'https://developer.mozilla.org/@api/deki/files/4585/=ex9.png', math: `<math display="block">
+        img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/ex9.png', math: `<math display="block">
         <msubsup>
           <mi>y</mi>
           <mn>3</mn>
           <mo>‴</mo>
         </msubsup>
       </math>` },
-      { img: 'https://mdn.mozillademos.org/files/13402/stirling29.png', math: `<math display="block"><mrow><munder><mo lspace="0em" rspace="0em">lim</mo><mrow><mi>n</mi><mo stretchy="false">→</mo><mo>+</mo><mn>∞</mn></mrow></munder><mfrac><msqrt><mrow><mn>2</mn><mi>π</mi><mi>n</mi></mrow></msqrt><mrow><mi>n</mi><mo>!</mo></mrow></mfrac><msup><mrow><mo>(</mo><mfrac><mi>n</mi><mi>e</mi></mfrac><mo>)</mo></mrow><mi>n</mi></msup></mrow><mo>=</mo><mn>1</mn></math>` },
-      { img: 'https://mdn.mozillademos.org/files/13438/determinant30.png', math: `<math display="block"><mrow><mrow><mo lspace="0em" rspace="0em">det</mo><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><munder><mo>∑</mo><mrow><mi>σ</mi><mo>∊</mo><msub><mi>S</mi><mi>n</mi></msub></mrow></munder><mrow><mi>ϵ</mi><mo stretchy="false">(</mo><mi>σ</mi><mo stretchy="false">)</mo></mrow><mrow><munderover><mo>∏</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><msub><mi>a</mi><mrow><mi>i</mi><mo>,</mo><msub><mi>σ</mi><mi>i</mi></msub></mrow></msub></mrow></mrow></math>` }
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/stirling29.png', math: `<math display="block"><mrow><munder><mo lspace="0em" rspace="0em">lim</mo><mrow><mi>n</mi><mo stretchy="false">→</mo><mo>+</mo><mn>∞</mn></mrow></munder><mfrac><msqrt><mrow><mn>2</mn><mi>π</mi><mi>n</mi></mrow></msqrt><mrow><mi>n</mi><mo>!</mo></mrow></mfrac><msup><mrow><mo>(</mo><mfrac><mi>n</mi><mi>e</mi></mfrac><mo>)</mo></mrow><mi>n</mi></msup></mrow><mo>=</mo><mn>1</mn></math>` },
+      { img: 'https://fred-wang.github.io/MathFonts/mozilla_mathml_test/resources/determinant30.png', math: `<math display="block"><mrow><mrow><mo lspace="0em" rspace="0em">det</mo><mo stretchy="false">(</mo><mi>A</mi><mo stretchy="false">)</mo></mrow><mo>=</mo><munder><mo>∑</mo><mrow><mi>σ</mi><mo>∊</mo><msub><mi>S</mi><mi>n</mi></msub></mrow></munder><mrow><mi>ϵ</mi><mo stretchy="false">(</mo><mi>σ</mi><mo stretchy="false">)</mo></mrow><mrow><munderover><mo>∏</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><msub><mi>a</mi><mrow><mi>i</mi><mo>,</mo><msub><mi>σ</mi><mi>i</mi></msub></mrow></msub></mrow></mrow></math>` }
     ];
 
     const table = document.querySelector('table');


### PR DESCRIPTION
This PR fixes the TeX images in the torture test to use the images at https://fred-wang.github.io/MathFonts/mozilla_mathml_test/ (which is what Mozilla links to now on their [MathML examples page](https://developer.mozilla.org/en-US/docs/Web/MathML/Examples)).